### PR TITLE
docs: add AGENTS.md with machine-maintainer guidance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,5 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every month
       interval: "monthly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -24,11 +24,10 @@ permissions:
 jobs:
   # Note: https://docs.github.com/en/actions/using-workflows/reusing-workflows The strategy property is not supported in any job that calls a reusable workflow.
   php-composer-unit-stan:
-    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.7
+    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.10
     with:
       # JSON
       php-version: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]'
-      runs-on: "ubuntu-latest"
 
   prettier-fix:
     needs: php-composer-unit-stan
@@ -61,6 +60,4 @@ jobs:
 
   super-linter:
     needs: phpcs-phpcbf
-    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.7
-    with:
-      runs-on: "ubuntu-latest"
+    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.10

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /vendor/
 #disable composer lock file
 /composer.lock
+#disable local Composer cache
+/.composer-cache/
 
 #disable IDE files
 /nbproject/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md
+
+## Repository Role
+
+This repository is an interface-only PHP library for the Seablast ecosystem. Treat `src/` as public contract code: preserve namespaces, method names, return types, PHPDoc return shapes, and Composer PSR-4 autoloading unless a change is intentionally breaking and documented as such.
+
+## Change Rules
+
+- Keep changes small and contract-focused. Do not add runtime behavior, dynamic execution, secrets, credentials, or side-effectful code to this package.
+- Never remove existing comments unless the comment is a TODO that the change fully solves, or unless translating the comment to English.
+- Update `CHANGELOG.md` in English for repository changes.
+- Respect dirty worktrees. Existing unrelated edits are user-owned; do not revert or rewrite them.
+- Keep security in mind for every change. Interface packages should not contain executable shortcuts, generated secrets, or environment-specific credentials.
+
+## Commands
+
+- PHP syntax check: `php -l src\IdentityManagerInterface.php`
+- Composer validation on Windows:
+  `$env:COMPOSER_CACHE_DIR = "$PWD\.composer-cache"; php "C:\ProgramData\ComposerSetup\bin\composer.phar" validate --strict`
+- PHPStan on Windows must run through Git Bash, not directly from PowerShell:
+  `& "C:\Program Files\Git\bin\bash.exe" -lc "./blast.sh phpstan"`
+- PHPStan cleanup on Windows:
+  `& "C:\Program Files\Git\bin\bash.exe" -lc "./blast.sh phpstan-remove"`
+- Do not modify Composer itself and do not run `composer self-update`.
+
+## Files And Folders To Avoid
+
+Do not inspect, lint, or recurse into `vendor/`, `nbproject/`, `.tmp/`, build artifacts, or cache directories unless a task explicitly requires it. `composer.lock` is ignored for this library and should not be treated as source.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This repository is an interface-only PHP library for the Seablast ecosystem. Tre
 ## Change Rules
 
 - Keep changes small and contract-focused. Do not add runtime behavior, dynamic execution, secrets, credentials, or side-effectful code to this package.
-- Never remove existing comments unless the comment is a TODO that the change fully solves, or unless translating the comment to English.
+- Never remove existing comments unless the comment is a todo that the change fully solves, or unless translating the comment to English.
 - Update `CHANGELOG.md` in English for repository changes.
 - Respect dirty worktrees. Existing unrelated edits are user-owned; do not revert or rewrite them.
 - Keep security in mind for every change. Interface packages should not contain executable shortcuts, generated secrets, or environment-specific credentials.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added` for new features
 
+- Added `AGENTS.md` with machine-maintainer guidance for this interface-only library.
+
 ### `Changed` for changes in existing functionality
+
+- Clarified the README example, polished `IdentityManagerInterface` PHPDoc, and ignored the local Composer cache directory.
 
 ### `Deprecated` for soon-to-be removed features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed` for changes in existing functionality
 
-- Clarified the README example, polished `IdentityManagerInterface` PHPDoc, and ignored the local Composer cache directory.
+- Clarified the readme example, polished `IdentityManagerInterface` PHPDoc, and ignored the local Composer cache directory.
 
 ### `Deprecated` for soon-to-be removed features
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 WorkOfStan
+Copyright (c) 2024-2026 WorkOfStan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To use the interfaces defined in `Seablast\Interfaces` within your project, simp
 ```json
 {
   "require": {
-    "seablast/interfaces": "^0.1.1"
+    "seablast/interfaces": "^0.1.2"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -27,17 +27,34 @@ Then, run `composer install` or `composer update` to install the dependency and 
 
 ## Example
 
-Here’s an example of how to implement an interface from `Seablast\Interfaces`:
+Here's an example of how to implement an interface from `Seablast\Interfaces`:
 
 ```php
-// src/Bar.php in Seablast\Auth
+// src/IdentityManager.php in a package that consumes seablast/interfaces
 namespace Seablast\Auth;
 
-use Seablast\Interfaces\BarInterface;
+use Seablast\Interfaces\IdentityManagerInterface;
 
-class Bar implements BarInterface {
-    public function doSomething() {
-        // Implementation of the method
+final class IdentityManager implements IdentityManagerInterface
+{
+    public function getGroups(): array
+    {
+        return [1, 2];
+    }
+
+    public function getRoleId(): int
+    {
+        return 1;
+    }
+
+    public function getUserId(): int
+    {
+        return 123;
+    }
+
+    public function isAuthenticated(): bool
+    {
+        return true;
     }
 }
 ```

--- a/blast.sh
+++ b/blast.sh
@@ -1,9 +1,16 @@
 #!/bin/bash
 # blast.sh - Management script for deployment and development of a Seablast application
-# Seablast:v0.2.11
+# Seablast:v0.2.17.3
+# Fail fast on real script errors:
+# -e: stop on unexpected non-zero exit codes
+# -u: treat unset variables as errors, which makes argument handling stricter
+# -o pipefail: fail a pipeline when any command in it fails
+set -euo pipefail
+
 # Usage:
 #   ./blast.sh                          # Runs assemble + creates required folders + checks web inaccessibility
-#   ./blast.sh --base-url http://localhost  # Checks if defined folders are inaccessible at http://localhost
+#   ./blast.sh --base-url http://localhost  # Runs the default action with a custom base URL for folder checks
+#   ./blast.sh clean                    # Previews and deletes temporary cache/audio marker files after confirmation
 #   ./blast.sh main                     # Switches to the main branch (after confirmation)
 #   ./blast.sh phpstan                  # Runs PHPStan without --pro
 #   ./blast.sh phpstan-pro              # Runs PHPStan with --pro
@@ -19,6 +26,12 @@ WARNING='\033[0;31m'   # Red for warnings
 display_header() { printf "${HIGHLIGHT}%s${NC}\n" "$1"; }
 display_warning() { printf "${WARNING}%s${NC}\n" "$1"; }
 
+# Shared usage output so CLI validation errors stay consistent.
+print_usage() {
+	echo "Usage: ./blast.sh [--base-url http://example.com] [clean|main|phpstan|phpstan-pro|phpstan-remove|self-update]"
+	echo "(See the beginning of the code for the explanation.)"
+}
+
 # Default base URL (can be overridden by --base-url)
 BASE_URL="http://localhost"
 
@@ -30,12 +43,17 @@ check_web_inaccessibility() {
 	local path="$1"
 	local url="${BASE_URL}${path}"
 	local status_code
-	status_code=$(curl -o /dev/null -s -w "%{http_code}" "$url")
 
-	if [ "$status_code" -eq 404 ] || [ "$status_code" -eq 403 ]; then
-		echo "✅ $url is correctly blocked ($status_code)."
+	# With `set -e`, run curl inside `if` so connection problems only warn and do not
+	# abort the whole setup when a local web server is temporarily unavailable.
+	if status_code=$(curl -o /dev/null -s -w "%{http_code}" "$url" 2>/dev/null); then
+		if [ "$status_code" -eq 404 ] || [ "$status_code" -eq 403 ]; then
+			echo "[OK] $url is correctly blocked ($status_code)."
+		else
+			display_warning "Warning: $url is accessible with status $status_code."
+		fi
 	else
-		display_warning "⚠️  Warning: $url is accessible with status $status_code."
+		display_warning "Warning: $url could not be checked because curl could not reach it."
 	fi
 }
 
@@ -48,19 +66,20 @@ setup_environment() {
 	if command -v curl &>/dev/null; then
 		has_curl=true
 	else
-		display_warning "⚠️  Warning: curl is not installed, so security of folders cannot be tested."
+		display_warning "Warning: curl is not installed, so security of folders cannot be tested."
 	fi
 	for folder in "${paths[@]}"; do
 		[ ! -d "$folder" ] && mkdir -p "$folder" && display_header "Created missing folder: $folder"
 		$has_curl && check_web_inaccessibility "/$folder/"
 	done
 
-	# Create local config if not present but the dist template is available, if newly created, then stop the script so that the admin may adapt the newly created config
+	# Create local config if not present but the dist template is available. If newly
+	# created, then stop the script so that the admin may adapt the new config first.
 	[[ ! -f "conf/app.conf.local.php" && -f "conf/app.conf.dist.php" ]] && cp -p conf/app.conf.dist.php conf/app.conf.local.php && display_warning "Check/modify the newly created conf/app.conf.local.php" && exit 0
 
 	# conf/phinx.local.php or at least conf/phinx.dist.php is required
 	if [[ ! -f "conf/phinx.local.php" ]]; then
-		[[ ! -f "conf/phinx.dist.php" ]] && display_warning "phinx config is required for a Seablast app" && exit 0
+		[[ ! -f "conf/phinx.dist.php" ]] && display_warning "conf/phinx.dist.php template is required for a Seablast app" && exit 0
 		cp -p conf/phinx.dist.php conf/phinx.local.php && display_warning "Check/modify the newly created conf/phinx.local.php"
 		exit 0
 	fi
@@ -72,7 +91,7 @@ run_phpunit() {
 		display_header "-- Running PHPUnit --"
 		vendor/bin/phpunit
 	else
-		display_warning "NO phpunit.xml CONFIGURATION"
+		display_warning "NO phpunit.xml CONFIGURATION, no PHPUnit testing"
 	fi
 }
 
@@ -84,11 +103,38 @@ assemble() {
 	display_header "-- Running database migrations --"
 	vendor/bin/phinx migrate -e development --configuration ./conf/phinx.local.php
 	display_header "-- Running database TESTING migrations --"
-	# In order to properly unit test all features, set-up a test database, put its credentials to testing section of phinx.yml and run phinx migrate -e testing before phpunit
-	# Drop tables in the testing database if changes were made to migrations
+	# In order to properly unit test all features, set-up a test database, put its
+	# credentials to the testing section of the phinx configuration file and run
+	# phinx migrate -e testing before phpunit.
+	# Drop tables in the testing database if changes were made to migrations.
 	vendor/bin/phinx migrate -e testing --configuration ./conf/phinx.local.php
 
 	run_phpunit
+}
+
+# Previews and removes temporary files created during development
+clean_temp_files() {
+	display_header "-- Files to be deleted (preview) --"
+	# ls returns non-zero when no glob matches, which is acceptable for this preview.
+	# We do not want the script to stop in that case, so we append "|| true".
+	ls -1 cache/*.php cache/*.lock uploads/audios/*.del 2>/dev/null || true
+	echo
+
+	read -r -p "Do you really want to delete the files listed above? Type YES to continue: " confirm
+	if [[ "${confirm}" != "YES" ]]; then
+		echo "Aborted."
+		exit 0
+	fi
+
+	display_header "-- Deleting temporary files --"
+	# -v: verbose, prints the name of each removed file
+	# -f: force, ignore nonexistent files and do not prompt
+	# Keep "2>/dev/null || true" so unmatched globs do not abort the script under
+	# `set -e` in environments with slightly different shell behaviour.
+	rm -fv cache/*.php cache/*.lock 2>/dev/null || true
+	rm -fv uploads/audios/*.del 2>/dev/null || true
+
+	echo "Done."
 }
 
 # Switches to the main branch
@@ -108,9 +154,12 @@ run_phpstan() {
 	composer install -a --prefer-dist --no-progress
 	display_header "-- Installing PHPStan (via Webmozart Assert plugin to allow for Assertions during static analysis) --"
 	composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress --with-all-dependencies
-	# TODO check if phpstan/phpstan-phpunit is needed
-	display_header "-- As PHPUnit>=7 is used the PHPUnit plugin is used for better compatibility ... --"
-	composer require --dev phpstan/phpstan-phpunit --prefer-dist --no-progress --with-all-dependencies
+	if [[ -f "phpunit.xml" ]]; then
+		display_header "-- As PHPUnit>=7 is used the PHPUnit plugin is used for better compatibility ... --"
+		composer require --dev phpstan/phpstan-phpunit --prefer-dist --no-progress --with-all-dependencies
+	else
+		display_warning "NO phpunit.xml CONFIGURATION, no PHPStan PHPUnit plugin required"
+	fi
 
 	run_phpunit
 
@@ -122,6 +171,7 @@ run_phpstan() {
 # Removes PHPStan package
 phpstan_remove() {
 	display_header "-- Removing PHPStan package --"
+	# It does not matter if phpstan/phpstan-phpunit was not required before.
 	composer remove --dev phpstan/phpstan-phpunit
 	composer remove --dev phpstan/phpstan-webmozart-assert
 }
@@ -141,14 +191,18 @@ self_update() {
 	fi
 }
 
-# Parse optional base-url argument
-case "$1" in
---base-url)
-	shift
-	BASE_URL="$1"
-	shift
-	;;
-esac
+# Parse optional base-url argument.
+# Under `set -u`, use `${1-}` / `${2-}` so a missing CLI value can be handled
+# with a friendly error instead of an immediate "unbound variable" exit.
+if [[ "${1-}" == "--base-url" ]]; then
+	if [[ -z "${2-}" ]]; then
+		display_warning "Missing value for --base-url."
+		print_usage
+		exit 1
+	fi
+	BASE_URL="$2"
+	shift 2
+fi
 
 # Default behavior when no arguments are provided
 if [ $# -eq 0 ]; then
@@ -160,7 +214,10 @@ if [ $# -eq 0 ]; then
 fi
 
 # Handle command-line parameters
-case "$1" in
+case "${1-}" in
+clean)
+	clean_temp_files
+	;;
 main)
 	printf "Switches your working tree to the specified branch: main. Git will then fetch from origin (showing you a verbose progress report), bringing in all branches and tags, deleting any remote-tracking branches that have been removed on the server, and then merge (not rebase) the corresponding remote branch into your current branch.\n"
 	read -r -n1 -p "Continue? [y/N] " reply
@@ -184,9 +241,8 @@ self-update)
 	self_update
 	;;
 *)
-	display_warning "❌ Unknown option: $1"
-	echo "Usage: ./blast.sh [--base-url http://example.com][main|phpstan|phpstan-pro|phpstan-remove|self-update]"
-	echo "(See the beginning of the code for the explanation.)"
+	display_warning "Unknown option: ${1-}"
+	print_usage
 	exit 1
 	;;
 esac

--- a/conf/phpstan.app.neon
+++ b/conf/phpstan.app.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 9
+    level: max
     excludePaths:
         analyse:
           - ../vendor

--- a/src/IdentityManagerInterface.php
+++ b/src/IdentityManagerInterface.php
@@ -14,7 +14,7 @@ interface IdentityManagerInterface
     /**
      * Return the list of groups to which the user belongs. It may be empty.
      *
-     * @return int[]
+     * @return array<int>
      */
     public function getGroups(): array;
 

--- a/src/IdentityManagerInterface.php
+++ b/src/IdentityManagerInterface.php
@@ -12,23 +12,26 @@ namespace Seablast\Interfaces;
 interface IdentityManagerInterface
 {
     /**
-     * Return the list of groups to which user belong. It may be empty.
+     * Return the list of groups to which the user belongs. It may be empty.
      *
      * @return int[]
      */
     public function getGroups(): array;
+
     /**
-     * Return the id of user's role.
+     * Return the user's role id.
      *
      * @return int
      */
     public function getRoleId(): int;
+
     /**
      * Return the user's id.
      *
      * @return int
      */
     public function getUserId(): int;
+
     /**
      * Determine whether the user is authenticated.
      *


### PR DESCRIPTION
### Added

- Added `AGENTS.md` with machine-maintainer guidance for this interface-only library.

### Changed

- Clarified the README example, polished `IdentityManagerInterface` PHPDoc, and ignored the local Composer cache directory.